### PR TITLE
Fix start scripts to not use dotenv

### DIFF
--- a/week-15/practices/08-thunk-action-creator/thunk-action-creator/backend/package.json
+++ b/week-15/practices/08-thunk-action-creator/thunk-action-creator/backend/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "nodemon -r dotenv/config ./bin/www",
+    "start": "nodemon ./bin/www",
     "db:setup": "sequelize db:migrate && sequelize db:seed:all"
   },
   "dependencies": {

--- a/week-15/practices/09-dispatch-thunk-actions/dispatch-thunk-actions/backend/package.json
+++ b/week-15/practices/09-dispatch-thunk-actions/dispatch-thunk-actions/backend/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "nodemon -r dotenv/config ./bin/www"
+    "start": "nodemon ./bin/www"
   },
   "dependencies": {
     "cookie-parser": "~1.4.4",


### PR DESCRIPTION
In the two thunk practices, I had originally been using `dotenv/config` in the `start` script while I was still using Sequelize with Postgres. Due to the conversion to SQLite,there's no need for a `.env` file, and thus, no need for the `dotenv` package.