### PR TITLE
reword readme

### DIFF
--- a/week-14/practices/14-context-part1/README.md
+++ b/week-14/practices/14-context-part1/README.md
@@ -20,7 +20,7 @@ this `context` directory, create a file called `HoroscopeContext.js`. This is
 where all your horoscope context will be placed.
 
 At the top of this file, import `createContext` from `react` and create your
-context called `HoroscopeContext`. If you're lost, don't forget to checkout
+context called `HoroscopeContext`. If you're lost, don't forget to check out
 [documentation][create-context]. Make sure to `export` your `HoroscopeContext`.
 
 Awesome! We have created our context, now let's use our provider.


### PR DESCRIPTION
- Reword this line:
  - At the top of this file, import `createContext` from `react` and create your
context called `HoroscopeContext`. You will not need a default value, so leave
it empty. 
    - you dont enter a value here since you're only creating the context, not the provider. remove that line.