### PR TITLE
add imports to Detail.js

### DIFF
--- a/week-14/practices/14a-context-part2/starter/src/components/Detail.js
+++ b/week-14/practices/14a-context-part2/starter/src/components/Detail.js
@@ -1,3 +1,6 @@
+import {useContext} from 'react';
+import {HoroscopeContext} from '../context/HoroscopeContext'
+
 const Detail = () => {
   return (
     <div className='details'>


### PR DESCRIPTION
- Readme says: In your `Detail` component (`src/components/Detail.js`), we should have already
imported `useContext` and `HoroscopeContext` but those imports are not there.
  - added those imports to Detail.js file.